### PR TITLE
Improve difficulty animation and lobby gating

### DIFF
--- a/applications/frontend/package-lock.json
+++ b/applications/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "nextfrontend",
       "version": "0.1.0",
       "dependencies": {
+        "framer-motion": "^12.18.1",
         "next": "15.3.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -3417,6 +3418,33 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.18.1",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.18.1.tgz",
+      "integrity": "sha512-6o4EDuRPLk4LSZ1kRnnEOurbQ86MklVk+Y1rFBUKiF+d2pCdvMjWVu0ZkyMVCTwl5UyTH2n/zJEJx+jvTYuxow==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.18.1",
+        "motion-utils": "^12.18.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -4688,6 +4716,21 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.18.1.tgz",
+      "integrity": "sha512-dR/4EYT23Snd+eUSLrde63Ws3oXQtJNw/krgautvTfwrN/2cHfCZMdu6CeTxVfRRWREW3Fy1f5vobRDiBb/q+w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.18.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.18.1.tgz",
+      "integrity": "sha512-az26YDU4WoDP0ueAkUtABLk2BIxe28d8NH1qWT8jPGhPyf44XTdDUh8pDk9OPphaSrR9McgpcJlgwSOIw/sfkA==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/applications/frontend/package.json
+++ b/applications/frontend/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "framer-motion": "^12.18.1",
     "next": "15.3.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/applications/frontend/src/components/Hero.tsx
+++ b/applications/frontend/src/components/Hero.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
 import { gameModes } from "../data/mockData";
 
 interface HeroProps {
@@ -225,38 +226,47 @@ const Hero: React.FC<HeroProps> = ({ onStartQuiz = () => {} }) => {
         </div>
 
         {/* Difficulty Selection */}
-        {selectedGameType && (
-          <div className="w-full max-w-6xl mb-12 animate-fade-in">
-            <h2 className="text-3xl font-bold text-center mb-8 text-black">
-              Schwierigkeitsgrad wählen
-            </h2>
+        <AnimatePresence>
+          {selectedGameType && (
+            <motion.div
+              key="difficulty"
+              initial={{ opacity: 0, y: -20 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -20 }}
+              transition={{ duration: 0.6 }}
+              className="w-full max-w-6xl mb-12"
+            >
+              <h2 className="text-3xl font-bold text-center mb-8 text-black">
+                Schwierigkeitsgrad wählen
+              </h2>
 
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4">
-              {Object.entries(gameModes).map(([key, mode], index) => (
-                <div
-                  key={key}
-                  onClick={() => setSelectedGameMode(key)}
-                  className={`p-6 cursor-pointer transition-all duration-300 rounded-xl shadow-lg transform hover:scale-105 hover:-translate-y-1 ${
-                    selectedGameMode === key
-                      ? "border-2 border-blue-500 bg-blue-50 shadow-xl scale-105"
-                      : "border-2 border-gray-200 bg-white hover:border-blue-300 hover:shadow-xl"
-                  }`}
-                  style={{ animationDelay: `${index * 50}ms` }}
-                >
-                  <div className="flex flex-col items-center text-center">
-                    <div
-                      className={`w-12 h-12 rounded-full ${mode.color} flex items-center justify-center mb-3 shadow-md`}
-                    >
-                      <span className="text-xl text-white">{mode.icon}</span>
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4">
+                {Object.entries(gameModes).map(([key, mode], index) => (
+                  <div
+                    key={key}
+                    onClick={() => setSelectedGameMode(key)}
+                    className={`p-6 cursor-pointer transition-all duration-300 rounded-xl shadow-lg transform hover:scale-105 hover:-translate-y-1 ${
+                      selectedGameMode === key
+                        ? "border-2 border-blue-500 bg-blue-50 shadow-xl scale-105"
+                        : "border-2 border-gray-200 bg-white hover:border-blue-300 hover:shadow-xl"
+                    }`}
+                    style={{ animationDelay: `${index * 50}ms` }}
+                  >
+                    <div className="flex flex-col items-center text-center">
+                      <div
+                        className={`w-12 h-12 rounded-full ${mode.color} flex items-center justify-center mb-3 shadow-md`}
+                      >
+                        <span className="text-xl text-white">{mode.icon}</span>
+                      </div>
+                      <h3 className="text-lg font-bold text-black mb-2">{mode.label}</h3>
+                      <p className="text-sm text-gray-600 leading-tight">{mode.description}</p>
                     </div>
-                    <h3 className="text-lg font-bold text-black mb-2">{mode.label}</h3>
-                    <p className="text-sm text-gray-600 leading-tight">{mode.description}</p>
                   </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
+                ))}
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
 
         {/* Start Button */}
         {selectedGameType && selectedGameMode && (
@@ -303,13 +313,19 @@ const Hero: React.FC<HeroProps> = ({ onStartQuiz = () => {} }) => {
               <div className="space-y-3">
                 <button
                   onClick={() => (window.location.href = "/lobby")}
-                  className="w-full py-3 px-6 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors font-medium"
+                  disabled={!selectedGameMode}
+                  className={`w-full py-3 px-6 bg-red-600 text-white rounded-lg transition-colors font-medium ${
+                    selectedGameMode ? "hover:bg-red-700" : "opacity-50 cursor-not-allowed"
+                  }`}
                 >
                   Neue Lobby erstellen
                 </button>
                 <button
                   onClick={() => (window.location.href = "/lobby")}
-                  className="w-full py-3 px-6 border-2 border-yellow-500 text-yellow-600 rounded-lg hover:bg-yellow-50 transition-colors font-medium"
+                  disabled={!selectedGameMode}
+                  className={`w-full py-3 px-6 border-2 border-yellow-500 text-yellow-600 rounded-lg transition-colors font-medium ${
+                    selectedGameMode ? "hover:bg-yellow-50" : "opacity-50 cursor-not-allowed"
+                  }`}
                 >
                   Bestehender Lobby beitreten
                 </button>


### PR DESCRIPTION
## Summary
- add `framer-motion` to handle simple animations
- animate the difficulty section reveal
- disable multiplayer lobby buttons until a difficulty is chosen

## Testing
- `npm run lint` *(fails: Do not use `<a>` etc.)*
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_6856b0c42adc8324b192f732064f498f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added smooth animation effects to the difficulty selection section for a more engaging user experience.

- **Enhancements**
  - Multiplayer action buttons (create/join lobby) are now visually disabled and unclickable until a game mode is selected, improving clarity and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->