### PR TITLE
Fix multiplayer host lock and restore answer state

### DIFF
--- a/applications/backend/src/routes/lobbies.ts
+++ b/applications/backend/src/routes/lobbies.ts
@@ -179,12 +179,12 @@ router.post("/:lobbyId/cleanup", async (req: Request, res: Response) => {
 
     if (lobby.gameState) {
       // Initialize scores
-      lobby.players.forEach((player) => {
+      lobby.players.forEach((player: { id: string }) => {
         playerScores[player.id] = 0;
       });
 
       // Calculate scores from correct answers
-      lobby.gameState.gameAnswers.forEach((answer) => {
+      lobby.gameState.gameAnswers.forEach((answer: { isCorrect: boolean; playerId: string }) => {
         if (answer.isCorrect) {
           playerScores[answer.playerId] = (playerScores[answer.playerId] || 0) + 100;
         }
@@ -193,7 +193,7 @@ router.post("/:lobbyId/cleanup", async (req: Request, res: Response) => {
 
     // Update players with final scores and remove lobby association
     await Promise.all(
-      lobby.players.map(async (player) => {
+      lobby.players.map(async (player: { id: string; score: number }) => {
         const finalScore = playerScores[player.id] || 0;
 
         await prisma.player.update({

--- a/applications/frontend/src/components/MultiplayerQuiz.tsx
+++ b/applications/frontend/src/components/MultiplayerQuiz.tsx
@@ -34,10 +34,28 @@ const MultiplayerQuiz: React.FC<MultiplayerQuizProps> = ({ lobbyId, playerId, is
   const [fetchError, setFetchError] = useState<string | null>(null);
   const [isProcessingAnswer, setIsProcessingAnswer] = useState(false);
 
+  // Restore score related state from localStorage on mount
+  useEffect(() => {
+    const storedScore = localStorage.getItem(`score_${lobbyId}_${playerId}`);
+    const storedCorrect = localStorage.getItem(`correct_${lobbyId}_${playerId}`);
+    const storedStreak = localStorage.getItem(`streak_${lobbyId}_${playerId}`);
+    if (storedScore) setScore(parseInt(storedScore, 10));
+    if (storedCorrect) setCorrectCount(parseInt(storedCorrect, 10));
+    if (storedStreak) setStreak(parseInt(storedStreak, 10));
+  }, [lobbyId, playerId]);
+
+  useEffect(() => {
+    localStorage.setItem(`score_${lobbyId}_${playerId}`, score.toString());
+    localStorage.setItem(`correct_${lobbyId}_${playerId}`, correctCount.toString());
+    localStorage.setItem(`streak_${lobbyId}_${playerId}`, streak.toString());
+  }, [score, correctCount, streak, lobbyId, playerId]);
+
   const fetchQuestion = useCallback(async () => {
     if (!lobbyId) return;
     try {
-      const res = await fetch(`http://localhost:3001/api/games/${lobbyId}/question`);
+      const res = await fetch(
+        `http://localhost:3001/api/games/${lobbyId}/question?playerId=${playerId}`
+      );
       if (res.ok) {
         const data = await res.json();
 
@@ -45,13 +63,30 @@ const MultiplayerQuiz: React.FC<MultiplayerQuizProps> = ({ lobbyId, playerId, is
         if (!currentQuestionId || currentQuestionId !== data.questionId) {
           setQuestion(data);
           setCurrentQuestionId(data.questionId);
-          setSelectedAnswer(null);
-          setIsAnswered(false);
-          setShowExplanation(false);
           setTimeLeft(30);
-          setIsWaitingForNext(false);
-          setIsProcessingAnswer(false);
           setFetchError(null);
+
+          if (data.playerAnswer) {
+            setSelectedAnswer(data.playerAnswer);
+            setIsAnswered(true);
+            setShowExplanation(true);
+            setCorrectAnswer(data.correctAnswer);
+            setExplanation(data.explanation);
+            if (!isHost) {
+              setIsWaitingForNext(true);
+            } else {
+              setIsWaitingForNext(false);
+            }
+          } else {
+            setSelectedAnswer(null);
+            setIsAnswered(false);
+            setShowExplanation(false);
+            setCorrectAnswer(null);
+            setExplanation("");
+            setIsWaitingForNext(false);
+          }
+
+          setIsProcessingAnswer(false);
         }
       } else if (res.status === 404) {
         // Game might be finished - trigger cleanup and redirect
@@ -69,7 +104,7 @@ const MultiplayerQuiz: React.FC<MultiplayerQuizProps> = ({ lobbyId, playerId, is
       console.error("Error fetching question:", error);
       setFetchError("Fehler beim Laden der Frage");
     }
-  }, [lobbyId, router, currentQuestionId]);
+  }, [lobbyId, playerId, isHost, router, currentQuestionId]);
   useEffect(() => {
     fetchQuestion();
     // More frequent polling for better synchronization
@@ -126,7 +161,30 @@ const MultiplayerQuiz: React.FC<MultiplayerQuizProps> = ({ lobbyId, playerId, is
           setStreak(0);
         }
 
-        setIsWaitingForNext(true);
+        if (!isHost) {
+          setIsWaitingForNext(true);
+        }
+      } else if (res.status === 409) {
+        const data = await res.json();
+        setCorrectAnswer(data.correctAnswer);
+        setExplanation(data.explanation);
+        setIsAnswered(true);
+        setShowExplanation(true);
+
+        if (data.correct) {
+          const nextStreak = streak + 1;
+          setStreak(nextStreak);
+          setCorrectCount(correctCount + 1);
+          setScore(score + 100 * nextStreak);
+        } else {
+          setStreak(0);
+        }
+
+        if (!isHost) {
+          setIsWaitingForNext(true);
+        } else {
+          setIsWaitingForNext(false);
+        }
       }
     } catch (error) {
       console.error("Error submitting answer:", error);


### PR DESCRIPTION
## Summary
- fetch player question with answer info and unique-constraint error handling
- keep host's Next button active
- persist and restore score locally in `MultiplayerQuiz`
- validate duplicate answers gracefully

## Testing
- `npm run lint`
- `npm run build` in `applications/frontend`
- `npm run build` in `applications/backend`


------
https://chatgpt.com/codex/tasks/task_e_685b0c1d4fb48324a242680e5ab87ac2