### PR TITLE
Fix multiplayer quiz resume and host flow

### DIFF
--- a/applications/backend/src/routes/lobbies.ts
+++ b/applications/backend/src/routes/lobbies.ts
@@ -179,12 +179,12 @@ router.post("/:lobbyId/cleanup", async (req: Request, res: Response) => {
 
     if (lobby.gameState) {
       // Initialize scores
-      lobby.players.forEach((player) => {
+      lobby.players.forEach((player: { id: string }) => {
         playerScores[player.id] = 0;
       });
 
       // Calculate scores from correct answers
-      lobby.gameState.gameAnswers.forEach((answer) => {
+      lobby.gameState.gameAnswers.forEach((answer: { isCorrect: boolean; playerId: string }) => {
         if (answer.isCorrect) {
           playerScores[answer.playerId] = (playerScores[answer.playerId] || 0) + 100;
         }
@@ -193,7 +193,7 @@ router.post("/:lobbyId/cleanup", async (req: Request, res: Response) => {
 
     // Update players with final scores and remove lobby association
     await Promise.all(
-      lobby.players.map(async (player) => {
+      lobby.players.map(async (player: { id: string; score: number }) => {
         const finalScore = playerScores[player.id] || 0;
 
         await prisma.player.update({

--- a/applications/frontend/tsconfig.json
+++ b/applications/frontend/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -18,9 +14,7 @@
     "jsx": "preserve",
     "incremental": true,
     "paths": {
-      "@/*": [
-        "./src/*"
-      ]
+      "@/*": ["./src/*"]
     },
     "plugins": [
       {
@@ -28,13 +22,6 @@
       }
     ]
   },
-  "include": [
-    "**/*.ts",
-    "**/*.tsx",
-    "next-env.d.ts",
-    ".next/types/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["**/*.ts", "**/*.tsx", "next-env.d.ts", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- persist state when reloading multiplayer quiz by returning player's answer and score from backend
- prevent duplicate answers using Prisma upsert
- enable host to advance after answering
- fix TypeScript build errors

## Testing
- `npm run format`
- `cd applications/frontend && npm run lint`
- `npm run build`
- `cd ../backend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685b0c1d4fb48324a242680e5ab87ac2