### PR TITLE
Fix Prisma reconnection logic

### DIFF
--- a/applications/backend/src/index.ts
+++ b/applications/backend/src/index.ts
@@ -13,6 +13,7 @@ import playersRouter from "./routes/players";
 import questionsRouter from "./routes/questions";
 import reflectionsRouter from "./routes/reflections";
 import { setupSocket } from "./socket/socketHandlers";
+import { connectWithRetry } from "./lib/prisma";
 
 const app = express();
 
@@ -43,6 +44,15 @@ const io = new Server(httpServer, {
 
 setupSocket(io);
 
-httpServer.listen(PORT, () => {
-  console.log(`Backend listening on port ${PORT}`);
+async function start() {
+  await connectWithRetry();
+
+  httpServer.listen(PORT, () => {
+    console.log(`Backend listening on port ${PORT}`);
+  });
+}
+
+start().catch((err) => {
+  console.error("Failed to start server", err);
+  process.exit(1);
 });


### PR DESCRIPTION
## Summary
- keep trying DB connection until successful
- export retry helper from `prisma.ts`
- wait for database before starting the server

## Testing
- `npm run lint`
- `npm run build` in `applications/backend`


------
https://chatgpt.com/codex/tasks/task_e_686a9ac7dac0832481c3e63e545c1db4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved server startup process with enhanced connection retry logic to ensure reliable startup.
  * Added explicit error handling during server startup, providing clearer feedback if startup fails.

* **Bug Fixes**
  * Improved reconnection handling to better detect and recover from lost connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->